### PR TITLE
✨ Feat : 공통 응답 객체 및 예외처리 핸들러 구현

### DIFF
--- a/src/main/java/gdg/baekya/hackathon/common/controller/ApiControllerAdvice.java
+++ b/src/main/java/gdg/baekya/hackathon/common/controller/ApiControllerAdvice.java
@@ -1,0 +1,61 @@
+package gdg.baekya.hackathon.common.controller;
+
+import gdg.baekya.hackathon.common.response.ApiResponse;
+import gdg.baekya.hackathon.common.error.CustomException;
+import gdg.baekya.hackathon.common.error.ErrorCode;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.TypeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+import java.util.NoSuchElementException;
+
+@Slf4j
+@RestControllerAdvice
+public class ApiControllerAdvice {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ApiResponse<?> handleValidationException(MethodArgumentNotValidException ex) {
+        CustomException exception = new CustomException(ErrorCode.BAD_REQUEST);
+        String message = ex.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        exception.getErrorCode().changeMessage(message);
+        return ApiResponse.fail(exception);
+    }
+
+    // 요청된 URL에 해당하는 핸들러가 없을 때 발생.
+    // 지원되지 않는 HTTP 메서드 요청 시 발생.
+    @ExceptionHandler(value = {NoHandlerFoundException.class, HttpRequestMethodNotSupportedException.class})
+    public ApiResponse<?> handleNoPageFoundException(Exception e) {
+        log.error("GLOBAL EXCEPTION {} 발생", e);
+        return ApiResponse.fail(new CustomException(ErrorCode.NOT_FOUND_END_POINT));
+    }
+
+    // 요청 파라미터가 예상한 타입과 일치하지 않을 때 발생.
+    @ExceptionHandler(value = TypeMismatchException.class)
+    public ApiResponse<?> handleMismatchException(Exception e) {
+        log.error("GLOBAL EXCEPTION {} 발생", e);
+        return ApiResponse.fail(new CustomException(ErrorCode.BAD_REQUEST));
+    }
+
+    // NullPointException 일 때, 예외처리
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler
+    public ApiResponse<?> handleNullPointException(NullPointerException e) {
+        log.error("GLOBAL EXCEPTION {} 발생", e);
+        return ApiResponse.fail(new CustomException(ErrorCode.BAD_REQUEST));
+    }
+
+    // NoSuchElementException, EntityNotFoundException 일 때, 예외처리
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    @ExceptionHandler(value = {NoSuchElementException.class,EntityNotFoundException.class})
+    public ApiResponse<?> handleNoSuchElementException(Exception e) {
+        log.error("GLOBAL EXCEPTION {} 발생", e);
+        return ApiResponse.fail(new CustomException(ErrorCode.NOT_FOUND_END_POINT));
+    }
+}

--- a/src/main/java/gdg/baekya/hackathon/common/error/CustomException.java
+++ b/src/main/java/gdg/baekya/hackathon/common/error/CustomException.java
@@ -1,0 +1,14 @@
+package gdg.baekya.hackathon.common.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomException extends RuntimeException{
+    private final ErrorCode errorCode;
+
+    public String getMessage() {
+        return errorCode.getMessage();
+    }
+}

--- a/src/main/java/gdg/baekya/hackathon/common/error/ErrorCode.java
+++ b/src/main/java/gdg/baekya/hackathon/common/error/ErrorCode.java
@@ -1,0 +1,51 @@
+package gdg.baekya.hackathon.common.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    // Test Error
+    TEST_ERROR(100, HttpStatus.BAD_REQUEST, "테스트 에러입니다."),
+    // 400 Bad Request
+    BAD_REQUEST(400, HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    // 403 Bad Reques
+    Forbidden(403, HttpStatus.FORBIDDEN, "접속 권한이 없습니다."),
+    // 404 Not Found
+    NOT_FOUND_END_POINT(404, HttpStatus.NOT_FOUND, "요청한 대상이 존재하지 않습니다."),
+    // 500 Internal Server Error
+    INTERNAL_SERVER_ERROR(500, HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
+
+    // 아파트
+
+
+    // 게시판
+
+    DUPLICATE_ERROR(409, HttpStatus.CONFLICT, "중복된 값이 이미 존재합니다");
+
+    // 주문 관련
+
+
+    // 오더 관련
+
+
+    // 상품 관련
+
+
+    // 리뷰 관련
+
+
+    // 유저 관련
+
+
+    private Integer code;
+    private HttpStatus httpStatus;
+    private String message;
+
+    public void changeMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/gdg/baekya/hackathon/common/error/ExceptionDto.java
+++ b/src/main/java/gdg/baekya/hackathon/common/error/ExceptionDto.java
@@ -1,0 +1,22 @@
+package gdg.baekya.hackathon.common.error;
+
+import lombok.Getter;
+import org.antlr.v4.runtime.misc.NotNull;
+
+@Getter
+public class ExceptionDto {
+    @NotNull
+    private final Integer code;
+
+    @NotNull
+    private final String message;
+
+    public ExceptionDto(ErrorCode errorCode) {
+        this.code = errorCode.getCode();
+        this.message = errorCode.getMessage();
+    }
+
+    public static ExceptionDto of(ErrorCode errorCode) {
+        return new ExceptionDto(errorCode);
+    }
+}

--- a/src/main/java/gdg/baekya/hackathon/common/response/ApiResponse.java
+++ b/src/main/java/gdg/baekya/hackathon/common/response/ApiResponse.java
@@ -1,0 +1,28 @@
+package gdg.baekya.hackathon.common.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import gdg.baekya.hackathon.common.error.CustomException;
+import gdg.baekya.hackathon.common.error.ExceptionDto;
+import io.micrometer.common.lang.Nullable;
+import org.springframework.http.HttpStatus;
+
+public record ApiResponse<T>(
+        @JsonIgnore
+        HttpStatus httpStatus,
+        boolean success,
+        @Nullable T data,
+        @Nullable ExceptionDto error
+) {
+
+    public static <T> ApiResponse<T> ok(@Nullable final T data) {
+        return new ApiResponse<>(HttpStatus.OK, true, data, null);
+    }
+
+    public static <T> ApiResponse<T> created(@Nullable final T data) {
+        return new ApiResponse<>(HttpStatus.CREATED, true, data, null);
+    }
+
+    public static <T> ApiResponse<T> fail(final CustomException e) {
+        return new ApiResponse<>(e.getErrorCode().getHttpStatus(), false, null, ExceptionDto.of(e.getErrorCode()));
+    }
+}


### PR DESCRIPTION
## 작업 개요

공통 응답과 예외 핸들러 정의했습니다.

## 작업 사항

공통응답 구현
예외 핸들러 구현

## 공통 응답 예시

실패 응답

```json
{
    "success": false,
    "data": null,
    "error": {
        "code": 404,
        "message": "요청한 대상이 존재하지 않습니다."
    }
}
```

성공 응답 (data는 예시입니다)

```json
{
    "success": true,
    "data": {
        "category": {
            "id": 1,
            "name": "노트북"
        },
        "product": {
            "id": 1,
            "pname": "맥북 2025",
            "pdesc": "테스트2",
            "price": 1000000,
            "stock": 20,
            "uploadFileNames": []
        },
        "discountRate": 10,
        "discountPrice": 900000
    },
    "error": null
}
```